### PR TITLE
feat: Add torch.compile support for ~2x faster inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,30 @@ Automatically configured based on your GPU:
 | NVIDIA SM 6.x and older (Pascal, Maxwell) | ❌ Disabled (uses math backend) |
 | AMD GPUs | ❌ Disabled (compatibility varies) |
 
+### 🔥 torch.compile (Experimental)
+Enable PyTorch 2.0+ compilation for **~2x faster inference** on supported GPUs:
+
+```bash
+# Enable torch.compile
+HEARTMULA_COMPILE=true python -m uvicorn backend.app.main:app --host 0.0.0.0 --port 8000
+
+# With max performance (slower first run, faster subsequent runs)
+HEARTMULA_COMPILE=true HEARTMULA_COMPILE_MODE=max-autotune python -m uvicorn backend.app.main:app --host 0.0.0.0 --port 8000
+```
+
+| Mode | Description |
+|------|-------------|
+| `default` | Good balance of compile time and performance |
+| `reduce-overhead` | Faster compilation, slightly less optimal code |
+| `max-autotune` | Best performance, but slowest compilation (recommended for production) |
+
+**Requirements:**
+- PyTorch 2.0+
+- **Linux/WSL2**: Install Triton (`pip install triton`)
+- **Windows**: Install Triton-Windows (`pip install -U 'triton-windows>=3.2,<3.3'`)
+
+> **Note:** First generation will be slower due to compilation. Subsequent generations benefit from the compiled kernels.
+
 ### 🎯 Smart Multi-GPU Detection
 Automatically selects the best GPU configuration:
 - **With 4-bit quantization**: Prioritizes fastest GPU (highest compute capability)
@@ -335,6 +359,8 @@ OLLAMA_HOST=http://localhost:11434
 | `HEARTMULA_MODEL_DIR` | `backend/models` | Custom model directory (share with ComfyUI, etc.) |
 | `HEARTMULA_4BIT` | `auto` | 4-bit quantization: `auto`, `true`, or `false` |
 | `HEARTMULA_SEQUENTIAL_OFFLOAD` | `auto` | Model swapping for low VRAM: `auto`, `true`, or `false` |
+| `HEARTMULA_COMPILE` | `false` | torch.compile for ~2x faster inference: `true` or `false` |
+| `HEARTMULA_COMPILE_MODE` | `default` | Compile mode: `default`, `reduce-overhead`, or `max-autotune` |
 | `HEARTMULA_VERSION` | `RL-3B-20260123` | Model version (latest RL-tuned model) |
 | `CUDA_VISIBLE_DEVICES` | all GPUs | Specify which GPUs to use (e.g., `0,1`) |
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,30 @@
 # OpenRouter API Key (optional - for cloud LLM access)
 # Get your key at https://openrouter.ai/
 OPENROUTER_API_KEY=your_openrouter_api_key_here
+
+# ===== GPU Configuration =====
+# Set to "true", "false", or "auto" (default: auto)
+# HEARTMULA_4BIT=auto
+
+# Set to "true" or "false" (default: auto-detected based on VRAM)
+# HEARTMULA_SEQUENTIAL_OFFLOAD=auto
+
+# ===== torch.compile (Performance Optimization) =====
+# Enable torch.compile for ~2x faster inference on supported GPUs
+# Requires PyTorch 2.0+ and Triton (pip install triton or triton-windows)
+# Set to "true" or "false" (default: false)
+# HEARTMULA_COMPILE=false
+
+# torch.compile mode: "default", "reduce-overhead", or "max-autotune"
+# - default: Good balance of compile time and performance
+# - reduce-overhead: Faster compilation, slightly less optimal code
+# - max-autotune: Best performance, but slowest compilation (recommended for production)
+# HEARTMULA_COMPILE_MODE=default
+
+# ===== Model Configuration =====
+# Model version to use (default: RL-3B-20260123)
+# Options: "3B", "RL-3B-20260123"
+# HEARTMULA_VERSION=RL-3B-20260123
+
+# Custom model directory (default: backend/models)
+# HEARTMULA_MODEL_DIR=/path/to/your/models


### PR DESCRIPTION
## Summary

This PR adds support for PyTorch 2.0+ `torch.compile` to significantly improve inference speed (~2x on supported GPUs like RTX 4090, A100).

## Changes

### New Environment Variables
- `HEARTMULA_COMPILE`: Enable torch.compile (`true`/`false`, default: `false`)
- `HEARTMULA_COMPILE_MODE`: Compile optimization mode (`default`/`reduce-overhead`/`max-autotune`)

### Code Changes
- Added `apply_torch_compile()` function that compiles the model backbone and decoder
- Auto-detects Triton availability and falls back to eager backend if not found
- Updated `create_quantized_pipeline()` with compile parameters
- Applied torch.compile to both quantized and non-quantized pipelines
- All configurations (single GPU, multi-GPU, sequential offload) now support torch.compile

### Documentation
- Updated `.env.example` with new configuration options
- Added torch.compile section to README.md with usage examples

## Usage

```bash
# Enable torch.compile
HEARTMULA_COMPILE=true python -m uvicorn backend.app.main:app --host 0.0.0.0 --port 8000

# With max performance mode
HEARTMULA_COMPILE=true HEARTMULA_COMPILE_MODE=max-autotune ./start.sh
```

## Requirements

- PyTorch 2.0+
- **Linux/WSL2**: `pip install triton`
- **Windows**: `pip install -U 'triton-windows>=3.2,<3.3'`

## Notes

- First generation will be slower due to compilation
- Subsequent generations benefit from compiled kernels
- Falls back gracefully if compilation fails

## Related

This implements a feature similar to [heartlib PR #64](https://github.com/HeartMuLa/heartlib/pull/64).