### PR TITLE
feat: Add custom API support for OpenAI-compatible endpoints

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,12 @@
 # Get your key at https://openrouter.ai/
 OPENROUTER_API_KEY=your_openrouter_api_key_here
 
+# ===== Custom API (OpenAI Compatible) =====
+# For connecting to vLLM, LocalAI, LM Studio, or any OpenAI-compatible endpoint
+# CUSTOM_API_BASE_URL=http://localhost:8080/v1
+# CUSTOM_API_KEY=your_api_key_here
+# CUSTOM_API_MODEL=your-model-name
+
 # ===== GPU Configuration =====
 # Set to "true", "false", or "auto" (default: auto)
 # HEARTMULA_4BIT=auto

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -651,15 +651,22 @@ async def reload_models(settings: GPUSettingsRequest, background_tasks: Backgrou
 def get_llm_settings():
     """Get current LLM provider settings."""
     settings = LLMService.get_settings()
-    # Mask API key for security (show only last 4 chars)
-    api_key = settings.get("openrouter_api_key", "")
-    masked_key = f"***{api_key[-4:]}" if api_key and len(api_key) > 4 else ""
+    # Mask API keys for security (show only last 4 chars)
+    openrouter_key = settings.get("openrouter_api_key", "")
+    masked_openrouter_key = f"***{openrouter_key[-4:]}" if openrouter_key and len(openrouter_key) > 4 else ""
+
+    custom_api_key = settings.get("custom_api_key", "")
+    masked_custom_key = f"***{custom_api_key[-4:]}" if custom_api_key and len(custom_api_key) > 4 else ""
 
     return {
         "ollama_host": settings.get("ollama_host", ""),
-        "openrouter_api_key": masked_key,
+        "openrouter_api_key": masked_openrouter_key,
         "ollama_available": LLMService.check_ollama_available(),
-        "openrouter_available": LLMService.check_openrouter_available()
+        "openrouter_available": LLMService.check_openrouter_available(),
+        "custom_api_base_url": settings.get("custom_api_base_url", ""),
+        "custom_api_key": masked_custom_key,
+        "custom_api_model": settings.get("custom_api_model", ""),
+        "custom_api_available": LLMService.check_custom_api_available()
     }
 
 
@@ -675,19 +682,38 @@ def update_llm_settings(settings: LLMSettingsRequest):
         LLMService.update_settings(openrouter_api_key=settings.openrouter_api_key)
         music_service.current_settings["openrouter_api_key"] = settings.openrouter_api_key
 
+    if settings.custom_api_base_url is not None:
+        LLMService.update_settings(custom_api_base_url=settings.custom_api_base_url)
+        music_service.current_settings["custom_api_base_url"] = settings.custom_api_base_url
+
+    if settings.custom_api_key is not None:
+        LLMService.update_settings(custom_api_key=settings.custom_api_key)
+        music_service.current_settings["custom_api_key"] = settings.custom_api_key
+
+    if settings.custom_api_model is not None:
+        LLMService.update_settings(custom_api_model=settings.custom_api_model)
+        music_service.current_settings["custom_api_model"] = settings.custom_api_model
+
     # Save to persistent storage
     music_service._save_settings()
 
     # Return updated settings
     current = LLMService.get_settings()
-    api_key = current.get("openrouter_api_key", "")
-    masked_key = f"***{api_key[-4:]}" if api_key and len(api_key) > 4 else ""
+    openrouter_key = current.get("openrouter_api_key", "")
+    masked_openrouter_key = f"***{openrouter_key[-4:]}" if openrouter_key and len(openrouter_key) > 4 else ""
+
+    custom_api_key = current.get("custom_api_key", "")
+    masked_custom_key = f"***{custom_api_key[-4:]}" if custom_api_key and len(custom_api_key) > 4 else ""
 
     return {
         "ollama_host": current.get("ollama_host", ""),
-        "openrouter_api_key": masked_key,
+        "openrouter_api_key": masked_openrouter_key,
         "ollama_available": LLMService.check_ollama_available(),
-        "openrouter_available": LLMService.check_openrouter_available()
+        "openrouter_available": LLMService.check_openrouter_available(),
+        "custom_api_base_url": current.get("custom_api_base_url", ""),
+        "custom_api_key": masked_custom_key,
+        "custom_api_model": current.get("custom_api_model", ""),
+        "custom_api_available": LLMService.check_custom_api_available()
     }
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -155,6 +155,9 @@ class ModelReloadResponse(SQLModel):
 class LLMSettingsRequest(SQLModel):
     ollama_host: Optional[str] = None
     openrouter_api_key: Optional[str] = None
+    custom_api_base_url: Optional[str] = None
+    custom_api_key: Optional[str] = None
+    custom_api_model: Optional[str] = None
 
 
 class LLMSettingsResponse(SQLModel):
@@ -162,3 +165,7 @@ class LLMSettingsResponse(SQLModel):
     openrouter_api_key: str  # Will be masked in response
     ollama_available: bool
     openrouter_available: bool
+    custom_api_base_url: str
+    custom_api_key: str  # Will be masked in response
+    custom_api_model: str
+    custom_api_available: bool

--- a/backend/app/services/music_service.py
+++ b/backend/app/services/music_service.py
@@ -755,7 +755,11 @@ class MusicService:
                 "torch_compile_mode": "default",
                 # LLM Provider settings
                 "ollama_host": "",
-                "openrouter_api_key": ""
+                "openrouter_api_key": "",
+                # Custom API settings
+                "custom_api_base_url": "",
+                "custom_api_key": "",
+                "custom_api_model": ""
             }
             # Load persisted settings from disk (overrides defaults)
             cls._instance._load_settings()
@@ -806,6 +810,13 @@ class MusicService:
                         LLMService.update_settings(ollama_host=saved["ollama_host"])
                     if "openrouter_api_key" in saved and saved["openrouter_api_key"]:
                         LLMService.update_settings(openrouter_api_key=saved["openrouter_api_key"])
+                    # Apply Custom API settings
+                    if "custom_api_base_url" in saved:
+                        LLMService.update_settings(custom_api_base_url=saved["custom_api_base_url"])
+                    if "custom_api_key" in saved:
+                        LLMService.update_settings(custom_api_key=saved["custom_api_key"])
+                    if "custom_api_model" in saved:
+                        LLMService.update_settings(custom_api_model=saved["custom_api_model"])
 
                     logger.info(f"[Settings] Loaded from {SETTINGS_FILE}: {self.current_settings}")
         except Exception as e:

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -21,7 +21,7 @@ export interface Job {
 export interface LLMModel {
     id: string;
     name: string;
-    provider: 'ollama' | 'openrouter';
+    provider: 'ollama' | 'openrouter' | 'custom';
 }
 
 export interface Playlist {
@@ -77,6 +77,10 @@ export interface LLMSettings {
     openrouter_api_key: string;
     ollama_available: boolean;
     openrouter_available: boolean;
+    custom_api_base_url: string;
+    custom_api_key: string;
+    custom_api_model: string;
+    custom_api_available: boolean;
 }
 
 export const api = {
@@ -352,7 +356,13 @@ export const api = {
         return res.data;
     },
 
-    updateLLMSettings: async (settings: { ollama_host?: string; openrouter_api_key?: string }): Promise<LLMSettings> => {
+    updateLLMSettings: async (settings: {
+        ollama_host?: string;
+        openrouter_api_key?: string;
+        custom_api_base_url?: string;
+        custom_api_key?: string;
+        custom_api_model?: string;
+    }): Promise<LLMSettings> => {
         const res = await axios.put(`${API_BASE_URL}/settings/llm`, settings);
         return res.data;
     }


### PR DESCRIPTION
Add support for connecting to any OpenAI-compatible API endpoint (vLLM, LocalAI, LM Studio, etc.) alongside existing Ollama and OpenRouter providers.

Changes:
- Add CUSTOM_API_BASE_URL, CUSTOM_API_KEY, CUSTOM_API_MODEL settings
- Implement _call_custom_api() method in LLMService
- Extend models.py with custom API fields in request/response
- Update main.py API endpoints to handle custom API settings
- Add settings persistence in music_service.py
- Update frontend api.ts interfaces and SettingsModal.tsx UI
- Add configuration examples in .env.example