### PR TITLE
Fix HeartCodec repo id

### DIFF
--- a/backend/app/services/music_service.py
+++ b/backend/app/services/music_service.py
@@ -50,7 +50,7 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 # HuggingFace model IDs (base repos - version is appended for HeartMuLa)
-HF_HEARTCODEC_REPO = "HeartMuLa/HeartCodec-oss"
+HF_HEARTCODEC_REPO = "HeartMuLa/HeartCodec-oss-20260123"
 HF_HEARTMULA_GEN_REPO = "HeartMuLa/HeartMuLaGen"  # Contains tokenizer.json and gen_config.json
 
 # Model version mapping - maps version to (HuggingFace repo, local folder name)


### PR DESCRIPTION
This fixes the 404 on first start by updating the HeartCodec HF repo ID to the current versioned repo (HeartCodec-oss-20260123). The previous ID now returns 404.