### PR TITLE
Add MiniMax music generation provider

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -34,3 +34,14 @@ OPENROUTER_API_KEY=your_openrouter_api_key_here
 
 # Custom model directory (default: backend/models)
 # HEARTMULA_MODEL_DIR=/path/to/your/models
+
+# ===== MiniMax Music Generation Provider =====
+# Optional: route music generation to the MiniMax music_generation API instead
+# of the local HeartMuLa pipelines.
+# MINIMAX_API_KEY=your_minimax_api_key_here
+# Region endpoint: "global_en" (api.minimax.io) or "cn_zh" (api.minimaxi.com)
+# MINIMAX_REGION=global_en
+# Audio output format: "url" (download link) or "hex" (raw PCM bytes)
+# MINIMAX_OUTPUT_FORMAT=url
+# China region only: AIGC watermark flag ("0" or "1")
+# MINIMAX_AIGC_WATERMARK=0

--- a/backend/app/services/minimax_service.py
+++ b/backend/app/services/minimax_service.py
@@ -1,0 +1,283 @@
+"""MiniMax music generation provider.
+
+This provider routes music generation jobs to the MiniMax ``music_generation``
+HTTP API instead of the local HeartMuLa/HeartCodec pipelines. It supports both
+the global (``api.minimax.io``) and China (``api.minimaxi.com``) regional
+endpoints, the generation and cover model families, the regional request
+fields, the synchronous status/audio response, and ``url``/``hex`` audio
+parsing.
+
+The provider is intentionally dependency-light: it only relies on ``requests``
+(already a project dependency) so it can be imported and unit-tested without
+the heavy torch/heartlib stack.
+"""
+
+import logging
+import os
+from typing import Optional, Tuple
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Regional endpoints for the music_generation operation.
+MINIMAX_MUSIC_ENDPOINTS = {
+    "global_en": "https://api.minimax.io/v1/music_generation",
+    "cn_zh": "https://api.minimaxi.com/v1/music_generation",
+}
+
+# Model families. Generation models create new music from a prompt/lyrics; cover
+# models re-sing an existing reference track. Names come from the provider's
+# published model list and are not hardcoded anywhere else in the codebase.
+MINIMAX_GENERATION_MODELS = ["music-3.0", "music-2.6", "music-3.0-free", "music-2.6-free"]
+MINIMAX_COVER_MODELS = ["music-cover", "music-cover-free"]
+MINIMAX_DEFAULT_MODEL = "music-3.0"
+
+# Output and audio format support.
+MINIMAX_OUTPUT_FORMATS = ["url", "hex"]
+MINIMAX_STREAM_OUTPUT_FORMATS = ["hex"]
+MINIMAX_AUDIO_FORMATS = ["mp3", "wav", "pcm"]
+
+# Regional request fields that only apply to specific regions.
+MINIMAX_REGIONAL_FIELDS = {
+    "global_en": [],
+    "cn_zh": ["aigc_watermark"],
+}
+
+# Response field contract (from the provider reference).
+STATUS_FIELD = "data.status"
+STATUS_IN_PROGRESS = 1
+STATUS_COMPLETED = 2
+AUDIO_FIELD = "data.audio"
+SUCCESS_CODE_FIELD = "base_resp.status_code"
+SUCCESS_CODE = 0
+
+# The music_generation call is synchronous: it holds the connection until the
+# track is ready and returns the audio inline. There is no separate task id or
+# query endpoint to poll.
+DEFAULT_TIMEOUT_SECONDS = 300
+DEFAULT_URL_TTL_HOURS = 24
+
+
+class MiniMaxMusicError(RuntimeError):
+    """Raised when the MiniMax music API returns an unusable response."""
+
+
+class MiniMaxMusicProvider:
+    """MiniMax music_generation HTTP client.
+
+    Configuration is read from the environment so the provider can be used
+    standalone, but callers may also pass explicit overrides.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        region: Optional[str] = None,
+        output_format: Optional[str] = None,
+        timeout: Optional[int] = None,
+    ):
+        self.api_key = api_key if api_key is not None else os.environ.get("MINIMAX_API_KEY", "")
+        self.region = region if region is not None else os.environ.get("MINIMAX_REGION", "global_en")
+        self.output_format = output_format if output_format is not None else os.environ.get(
+            "MINIMAX_OUTPUT_FORMAT", "url"
+        )
+        self.timeout = timeout if timeout is not None else DEFAULT_TIMEOUT_SECONDS
+
+        if not self.api_key:
+            raise MiniMaxMusicError("MINIMAX_API_KEY is not configured")
+        if self.region not in MINIMAX_MUSIC_ENDPOINTS:
+            raise MiniMaxMusicError(
+                f"Unknown MiniMax region '{self.region}'. "
+                f"Expected one of: {', '.join(sorted(MINIMAX_MUSIC_ENDPOINTS))}"
+            )
+        if self.output_format not in MINIMAX_OUTPUT_FORMATS:
+            raise MiniMaxMusicError(
+                f"Unknown MiniMax output_format '{self.output_format}'. "
+                f"Expected one of: {', '.join(MINIMAX_OUTPUT_FORMATS)}"
+            )
+
+    @property
+    def endpoint(self) -> str:
+        return MINIMAX_MUSIC_ENDPOINTS[self.region]
+
+    @staticmethod
+    def is_cover_model(model: str) -> bool:
+        return model in MINIMAX_COVER_MODELS
+
+    @staticmethod
+    def is_generation_model(model: str) -> bool:
+        return model in MINIMAX_GENERATION_MODELS
+
+    @staticmethod
+    def resolve_model(model: Optional[str], cover: bool = False) -> str:
+        """Pick a valid model id, defaulting to the published default."""
+        if model:
+            if model not in (MINIMAX_GENERATION_MODELS + MINIMAX_COVER_MODELS):
+                raise MiniMaxMusicError(f"Unknown MiniMax music model: {model}")
+            return model
+        if cover:
+            return MINIMAX_COVER_MODELS[0]
+        return MINIMAX_DEFAULT_MODEL
+
+    def _headers(self) -> dict:
+        # Authorization scheme is Bearer per the provider reference.
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _build_payload(
+        self,
+        model: str,
+        prompt: Optional[str],
+        lyrics: Optional[str],
+        is_instrumental: bool = False,
+        cover_feature_id: Optional[str] = None,
+        audio_url: Optional[str] = None,
+        audio_base64: Optional[str] = None,
+    ) -> dict:
+        """Build the request payload, applying regional fields per region."""
+        payload = {
+            "model": model,
+            "output_format": self.output_format,
+        }
+
+        if prompt:
+            payload["prompt"] = prompt
+        if lyrics:
+            payload["lyrics"] = lyrics
+        if is_instrumental:
+            payload["is_instrumental"] = True
+        if cover_feature_id:
+            payload["cover_feature_id"] = cover_feature_id
+
+        # Cover models require exactly one reference-audio input.
+        if self.is_cover_model(model):
+            if audio_url:
+                payload["audio_url"] = audio_url
+            elif audio_base64:
+                payload["audio_base64"] = audio_base64
+            else:
+                raise MiniMaxMusicError(
+                    "Cover models require one of 'audio_url' or 'audio_base64'."
+                )
+
+        # Regional fields: only the China (cn_zh) region accepts aigc_watermark.
+        for field_name in MINIMAX_REGIONAL_FIELDS.get(self.region, []):
+            if field_name == "aigc_watermark":
+                payload["aigc_watermark"] = os.environ.get("MINIMAX_AIGC_WATERMARK", "0")
+        return payload
+
+    def _post(self, payload: dict) -> dict:
+        logger.info(
+            "[MiniMax] POST %s (model=%s, output_format=%s)",
+            self.endpoint,
+            payload.get("model"),
+            self.output_format,
+        )
+        try:
+            resp = requests.post(
+                self.endpoint,
+                headers=self._headers(),
+                json=payload,
+                timeout=self.timeout,
+            )
+        except requests.RequestException as exc:
+            raise MiniMaxMusicError(f"MiniMax request failed: {exc}") from exc
+
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise MiniMaxMusicError(
+                f"MiniMax returned non-JSON response (HTTP {resp.status_code}): {exc}"
+            ) from exc
+
+        return data
+
+    @staticmethod
+    def _get_nested(data: dict, dotted: str):
+        """Fetch a dotted path like 'data.status' or 'base_resp.status_code'."""
+        current = data
+        for part in dotted.split("."):
+            if not isinstance(current, dict) or part not in current:
+                return None
+            current = current[part]
+        return current
+
+    def _parse_response(self, data: dict) -> Tuple[str, str]:
+        """Validate the synchronous response and return (audio, audio_format).
+
+        ``audio`` is either a download URL (output_format=url) or raw hex bytes
+        decoded from the response (output_format=hex). ``audio_format`` is the
+        file extension to use when saving the result.
+        """
+        status_code = self._get_nested(data, SUCCESS_CODE_FIELD)
+        if status_code != SUCCESS_CODE:
+            raise MiniMaxMusicError(
+                f"MiniMax request failed (base_resp.status_code={status_code}): {data}"
+            )
+
+        status = self._get_nested(data, STATUS_FIELD)
+        if status == STATUS_IN_PROGRESS:
+            raise MiniMaxMusicError(
+                "MiniMax returned in_progress status with no query endpoint"
+            )
+        if status != STATUS_COMPLETED:
+            raise MiniMaxMusicError(f"Unexpected MiniMax status: {status}")
+
+        audio = self._get_nested(data, AUDIO_FIELD)
+        if not audio:
+            raise MiniMaxMusicError(
+                f"MiniMax response missing audio field '{AUDIO_FIELD}': {data}"
+            )
+
+        if self.output_format == "hex":
+            # data.audio is a hex-encoded byte string of PCM audio.
+            try:
+                decoded = bytes.fromhex(audio)
+            except (ValueError, TypeError) as exc:
+                raise MiniMaxMusicError(f"Failed to decode hex audio: {exc}") from exc
+            return decoded, "pcm"
+
+        # output_format == "url": data.audio is a temporary download URL.
+        return audio, "mp3"
+
+    def generate(
+        self,
+        prompt: Optional[str] = None,
+        lyrics: Optional[str] = None,
+        model: Optional[str] = None,
+        is_instrumental: bool = False,
+        cover_feature_id: Optional[str] = None,
+        audio_url: Optional[str] = None,
+        audio_base64: Optional[str] = None,
+    ) -> Tuple[bytes, str]:
+        """Run a music generation/cover job and return (audio_bytes, ext).
+
+        For generation models, ``prompt``/``lyrics`` drive the output. For cover
+        models, one of ``audio_url``/``audio_base64`` is required as the source
+        track to re-sing.
+        """
+        cover = self.is_cover_model(model) if model else False
+        resolved_model = self.resolve_model(model, cover=cover)
+        payload = self._build_payload(
+            model=resolved_model,
+            prompt=prompt,
+            lyrics=lyrics,
+            is_instrumental=is_instrumental,
+            cover_feature_id=cover_feature_id,
+            audio_url=audio_url,
+            audio_base64=audio_base64,
+        )
+        data = self._post(payload)
+        return self._parse_response(data)
+
+    def download_audio(self, url: str) -> bytes:
+        """Download a URL-mode audio result returned by the API."""
+        try:
+            resp = requests.get(url, timeout=self.timeout)
+            resp.raise_for_status()
+        except requests.RequestException as exc:
+            raise MiniMaxMusicError(f"Failed to download MiniMax audio: {exc}") from exc
+        return resp.content

--- a/backend/app/services/minimax_service.py
+++ b/backend/app/services/minimax_service.py
@@ -12,6 +12,7 @@ The provider is intentionally dependency-light: it only relies on ``requests``
 the heavy torch/heartlib stack.
 """
 
+import base64
 import logging
 import os
 from typing import Optional, Tuple
@@ -37,6 +38,9 @@ MINIMAX_DEFAULT_MODEL = "music-3.0"
 MINIMAX_OUTPUT_FORMATS = ["url", "hex"]
 MINIMAX_STREAM_OUTPUT_FORMATS = ["hex"]
 MINIMAX_AUDIO_FORMATS = ["mp3", "wav", "pcm"]
+COVER_MIN_SECONDS = 6
+COVER_MAX_SECONDS = 360
+COVER_MAX_BYTES = 50 * 1024 * 1024
 
 # Regional request fields that only apply to specific regions.
 MINIMAX_REGIONAL_FIELDS = {
@@ -136,11 +140,19 @@ class MiniMaxMusicProvider:
         cover_feature_id: Optional[str] = None,
         audio_url: Optional[str] = None,
         audio_base64: Optional[str] = None,
+        stream: bool = False,
+        audio_setting: Optional[dict] = None,
+        lyrics_optimizer: Optional[bool] = None,
+        audio_duration_seconds: Optional[float] = None,
+        audio_size_bytes: Optional[int] = None,
     ) -> dict:
         """Build the request payload, applying regional fields per region."""
+        if stream and self.output_format not in MINIMAX_STREAM_OUTPUT_FORMATS:
+            raise MiniMaxMusicError("Streaming music responses require output_format='hex'.")
         payload = {
             "model": model,
             "output_format": self.output_format,
+            "stream": stream,
         }
 
         if prompt:
@@ -149,19 +161,47 @@ class MiniMaxMusicProvider:
             payload["lyrics"] = lyrics
         if is_instrumental:
             payload["is_instrumental"] = True
-        if cover_feature_id:
-            payload["cover_feature_id"] = cover_feature_id
+        if audio_setting is not None:
+            audio_format = audio_setting.get("format")
+            if audio_format is not None and audio_format not in MINIMAX_AUDIO_FORMATS:
+                raise MiniMaxMusicError(f"Unsupported audio format: {audio_format}")
+            payload["audio_setting"] = audio_setting
+        if lyrics_optimizer is not None:
+            payload["lyrics_optimizer"] = lyrics_optimizer
 
-        # Cover models require exactly one reference-audio input.
+        # Cover models require exactly one direct or preprocessed audio input.
         if self.is_cover_model(model):
-            if audio_url:
-                payload["audio_url"] = audio_url
-            elif audio_base64:
-                payload["audio_base64"] = audio_base64
-            else:
+            cover_inputs = sum(bool(value) for value in (audio_url, audio_base64, cover_feature_id))
+            if cover_inputs != 1:
                 raise MiniMaxMusicError(
-                    "Cover models require one of 'audio_url' or 'audio_base64'."
+                    "Cover models require exactly one of 'audio_url', 'audio_base64', "
+                    "or 'cover_feature_id'."
                 )
+            if cover_feature_id:
+                payload["cover_feature_id"] = cover_feature_id
+            else:
+                if audio_duration_seconds is None:
+                    raise MiniMaxMusicError("Cover audio duration is required for validation.")
+                if not COVER_MIN_SECONDS <= audio_duration_seconds <= COVER_MAX_SECONDS:
+                    raise MiniMaxMusicError(
+                        f"Cover audio duration must be between {COVER_MIN_SECONDS} "
+                        f"and {COVER_MAX_SECONDS} seconds."
+                    )
+                if audio_base64:
+                    try:
+                        measured_size = len(base64.b64decode(audio_base64, validate=True))
+                    except (ValueError, TypeError) as exc:
+                        raise MiniMaxMusicError("Cover audio_base64 is invalid.") from exc
+                elif audio_size_bytes is None:
+                    raise MiniMaxMusicError("Cover audio size is required for URL inputs.")
+                else:
+                    measured_size = audio_size_bytes
+                if measured_size > COVER_MAX_BYTES:
+                    raise MiniMaxMusicError("Cover audio must not exceed 50 MB.")
+                if audio_url:
+                    payload["audio_url"] = audio_url
+                else:
+                    payload["audio_base64"] = audio_base64
 
         # Regional fields: only the China (cn_zh) region accepts aigc_watermark.
         for field_name in MINIMAX_REGIONAL_FIELDS.get(self.region, []):
@@ -252,6 +292,11 @@ class MiniMaxMusicProvider:
         cover_feature_id: Optional[str] = None,
         audio_url: Optional[str] = None,
         audio_base64: Optional[str] = None,
+        stream: bool = False,
+        audio_setting: Optional[dict] = None,
+        lyrics_optimizer: Optional[bool] = None,
+        audio_duration_seconds: Optional[float] = None,
+        audio_size_bytes: Optional[int] = None,
     ) -> Tuple[bytes, str]:
         """Run a music generation/cover job and return (audio_bytes, ext).
 
@@ -269,6 +314,11 @@ class MiniMaxMusicProvider:
             cover_feature_id=cover_feature_id,
             audio_url=audio_url,
             audio_base64=audio_base64,
+            stream=stream,
+            audio_setting=audio_setting,
+            lyrics_optimizer=lyrics_optimizer,
+            audio_duration_seconds=audio_duration_seconds,
+            audio_size_bytes=audio_size_bytes,
         )
         data = self._post(payload)
         return self._parse_response(data)

--- a/backend/tests/test_minimax_service.py
+++ b/backend/tests/test_minimax_service.py
@@ -71,6 +71,26 @@ def test_payload_generation_model_fields():
     assert payload["lyrics"] == "[Verse] la la la"
     assert payload["output_format"] == "url"
     assert "aigc_watermark" not in payload
+    assert payload["stream"] is False
+
+
+def test_payload_optional_generation_settings():
+    p = _make_provider(output_format="hex")
+    payload = p._build_payload(
+        model="music-3.0", prompt="x", lyrics=None, stream=True,
+        audio_setting={"format": "wav", "sample_rate": 44100},
+        lyrics_optimizer=True,
+    )
+    assert payload["stream"] is True
+    assert payload["audio_setting"] == {"format": "wav", "sample_rate": 44100}
+    assert payload["lyrics_optimizer"] is True
+
+
+def test_stream_requires_hex_output():
+    with pytest.raises(MiniMaxMusicError, match="require output_format='hex'"):
+        _make_provider()._build_payload(
+            model="music-3.0", prompt="x", lyrics=None, stream=True,
+        )
 
 
 def test_payload_instrumental_flag():
@@ -104,6 +124,8 @@ def test_cover_model_accepts_audio_url():
     payload = p._build_payload(
         model="music-cover", prompt=None, lyrics=None,
         audio_url="https://example.com/track.mp3",
+        audio_duration_seconds=60,
+        audio_size_bytes=1024,
     )
     assert payload["audio_url"] == "https://example.com/track.mp3"
 
@@ -112,8 +134,53 @@ def test_cover_model_accepts_audio_base64():
     p = _make_provider()
     payload = p._build_payload(
         model="music-cover", prompt=None, lyrics=None, audio_base64="AAAA",
+        audio_duration_seconds=60,
     )
     assert payload["audio_base64"] == "AAAA"
+
+
+def test_cover_model_accepts_preprocessed_feature():
+    payload = _make_provider()._build_payload(
+        model="music-cover", prompt=None, lyrics="replacement lyrics",
+        cover_feature_id="feature-id",
+    )
+    assert payload["cover_feature_id"] == "feature-id"
+
+
+def test_cover_model_rejects_both_audio_inputs():
+    with pytest.raises(MiniMaxMusicError, match="exactly one"):
+        _make_provider()._build_payload(
+            model="music-cover", prompt=None, lyrics=None,
+            audio_url="https://example.com/track.mp3", audio_base64="AAAA",
+            audio_duration_seconds=60, audio_size_bytes=1024,
+        )
+
+
+def test_cover_model_rejects_direct_and_preprocessed_inputs():
+    with pytest.raises(MiniMaxMusicError, match="exactly one"):
+        _make_provider()._build_payload(
+            model="music-cover", prompt=None, lyrics="replacement lyrics",
+            audio_url="https://example.com/track.mp3", cover_feature_id="feature-id",
+            audio_duration_seconds=60, audio_size_bytes=1024,
+        )
+
+
+@pytest.mark.parametrize("duration", [5, 361])
+def test_cover_model_validates_duration(duration):
+    with pytest.raises(MiniMaxMusicError, match="duration"):
+        _make_provider()._build_payload(
+            model="music-cover", prompt=None, lyrics=None,
+            audio_base64="AAAA", audio_duration_seconds=duration,
+        )
+
+
+def test_cover_model_validates_size():
+    with pytest.raises(MiniMaxMusicError, match="50 MB"):
+        _make_provider()._build_payload(
+            model="music-cover", prompt=None, lyrics=None,
+            audio_url="https://example.com/track.mp3", audio_duration_seconds=60,
+            audio_size_bytes=50 * 1024 * 1024 + 1,
+        )
 
 
 def test_parse_url_response():
@@ -223,7 +290,8 @@ def test_generate_cover_model_sends_audio_url():
 
     with patch("backend.app.services.minimax_service.requests.post", side_effect=fake_post):
         p.generate(prompt=None, lyrics=None, model="music-cover",
-                   audio_url="https://example.com/src.mp3")
+                   audio_url="https://example.com/src.mp3",
+                   audio_duration_seconds=60, audio_size_bytes=1024)
 
     assert captured["json"]["model"] == "music-cover"
     assert captured["json"]["audio_url"] == "https://example.com/src.mp3"

--- a/backend/tests/test_minimax_service.py
+++ b/backend/tests/test_minimax_service.py
@@ -1,0 +1,261 @@
+"""Tests for the MiniMax music generation provider.
+
+These tests stub the network layer so they run without a MiniMax API key and
+without the heavy torch/heartlib dependencies.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests as _requests
+
+# Make ``backend`` importable when running from the repository root.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from backend.app.services.minimax_service import (  # noqa: E402
+    MINIMAX_MUSIC_ENDPOINTS,
+    MiniMaxMusicError,
+    MiniMaxMusicProvider,
+)
+
+
+def _make_provider(**overrides):
+    base = {"api_key": "test-key", "region": "global_en", "output_format": "url"}
+    base.update(overrides)
+    return MiniMaxMusicProvider(**base)
+
+
+def test_endpoints_cover_both_regions():
+    assert MINIMAX_MUSIC_ENDPOINTS["global_en"] == "https://api.minimax.io/v1/music_generation"
+    assert MINIMAX_MUSIC_ENDPOINTS["cn_zh"] == "https://api.minimaxi.com/v1/music_generation"
+
+
+def test_requires_api_key():
+    with pytest.raises(MiniMaxMusicError):
+        MiniMaxMusicProvider(api_key="", region="global_en")
+
+
+def test_rejects_unknown_region():
+    with pytest.raises(MiniMaxMusicError):
+        MiniMaxMusicProvider(api_key="k", region="mars")
+
+
+def test_rejects_unknown_output_format():
+    with pytest.raises(MiniMaxMusicError):
+        MiniMaxMusicProvider(api_key="k", region="global_en", output_format="flac")
+
+
+def test_resolves_default_generation_model():
+    assert _make_provider().resolve_model(None, cover=False) == "music-3.0"
+
+
+def test_resolves_default_cover_model():
+    assert _make_provider().resolve_model(None, cover=True) == "music-cover"
+
+
+def test_rejects_unknown_model():
+    with pytest.raises(MiniMaxMusicError):
+        _make_provider().resolve_model("not-a-model")
+
+
+def test_payload_generation_model_fields():
+    p = _make_provider()
+    payload = p._build_payload(
+        model="music-3.0", prompt="upbeat electronic",
+        lyrics="[Verse] la la la", is_instrumental=False,
+    )
+    assert payload["model"] == "music-3.0"
+    assert payload["prompt"] == "upbeat electronic"
+    assert payload["lyrics"] == "[Verse] la la la"
+    assert payload["output_format"] == "url"
+    assert "aigc_watermark" not in payload
+
+
+def test_payload_instrumental_flag():
+    p = _make_provider()
+    payload = p._build_payload(model="music-3.0", prompt=None, lyrics=None, is_instrumental=True)
+    assert payload["is_instrumental"] is True
+    assert "lyrics" not in payload
+    assert "prompt" not in payload
+
+
+def test_payload_cn_region_adds_aigc_watermark():
+    p = _make_provider(region="cn_zh")
+    payload = p._build_payload(model="music-3.0", prompt="x", lyrics=None)
+    assert payload["aigc_watermark"] == os.environ.get("MINIMAX_AIGC_WATERMARK", "0")
+
+
+def test_payload_global_region_omits_aigc_watermark():
+    p = _make_provider(region="global_en")
+    payload = p._build_payload(model="music-3.0", prompt="x", lyrics=None)
+    assert "aigc_watermark" not in payload
+
+
+def test_cover_model_requires_audio_input():
+    p = _make_provider()
+    with pytest.raises(MiniMaxMusicError):
+        p._build_payload(model="music-cover", prompt="x", lyrics=None)
+
+
+def test_cover_model_accepts_audio_url():
+    p = _make_provider()
+    payload = p._build_payload(
+        model="music-cover", prompt=None, lyrics=None,
+        audio_url="https://example.com/track.mp3",
+    )
+    assert payload["audio_url"] == "https://example.com/track.mp3"
+
+
+def test_cover_model_accepts_audio_base64():
+    p = _make_provider()
+    payload = p._build_payload(
+        model="music-cover", prompt=None, lyrics=None, audio_base64="AAAA",
+    )
+    assert payload["audio_base64"] == "AAAA"
+
+
+def test_parse_url_response():
+    p = _make_provider(output_format="url")
+    data = {"base_resp": {"status_code": 0}, "data": {"status": 2, "audio": "https://cdn.example.com/song.mp3"}}
+    audio, ext = p._parse_response(data)
+    assert audio == "https://cdn.example.com/song.mp3"
+    assert ext == "mp3"
+
+
+def test_parse_hex_response():
+    p = _make_provider(output_format="hex")
+    data = {"base_resp": {"status_code": 0}, "data": {"status": 2, "audio": "48656c6c6f"}}
+    audio, ext = p._parse_response(data)
+    assert audio == b"Hello"
+    assert ext == "pcm"
+
+
+def test_parse_response_rejects_nonzero_status_code():
+    p = _make_provider()
+    data = {"base_resp": {"status_code": 1004}, "data": {"status": 2, "audio": "x"}}
+    with pytest.raises(MiniMaxMusicError):
+        p._parse_response(data)
+
+
+def test_parse_response_rejects_in_progress():
+    p = _make_provider()
+    data = {"base_resp": {"status_code": 0}, "data": {"status": 1}}
+    with pytest.raises(MiniMaxMusicError):
+        p._parse_response(data)
+
+
+def test_parse_response_rejects_missing_audio():
+    p = _make_provider()
+    data = {"base_resp": {"status_code": 0}, "data": {"status": 2}}
+    with pytest.raises(MiniMaxMusicError):
+        p._parse_response(data)
+
+
+def test_parse_response_rejects_invalid_hex():
+    p = _make_provider(output_format="hex")
+    data = {"base_resp": {"status_code": 0}, "data": {"status": 2, "audio": "ZZ"}}
+    with pytest.raises(MiniMaxMusicError):
+        p._parse_response(data)
+
+
+def _fake_response(json_data=None, status_code=200):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    return resp
+
+
+def test_generate_global_en_posts_to_global_endpoint():
+    p = _make_provider(region="global_en")
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        return _fake_response(json_data={
+            "base_resp": {"status_code": 0},
+            "data": {"status": 2, "audio": "https://cdn.example.com/song.mp3"},
+        })
+
+    with patch("backend.app.services.minimax_service.requests.post", side_effect=fake_post):
+        audio, ext = p.generate(prompt="calm piano", lyrics=None, model="music-3.0")
+
+    assert captured["url"] == "https://api.minimax.io/v1/music_generation"
+    assert captured["json"]["model"] == "music-3.0"
+    assert captured["json"]["prompt"] == "calm piano"
+    assert audio == "https://cdn.example.com/song.mp3"
+    assert ext == "mp3"
+
+
+def test_generate_cn_zh_posts_to_cn_endpoint_and_adds_watermark():
+    p = _make_provider(region="cn_zh")
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers
+        return _fake_response(json_data={
+            "base_resp": {"status_code": 0},
+            "data": {"status": 2, "audio": "https://cdn.example.com/song.mp3"},
+        })
+
+    with patch("backend.app.services.minimax_service.requests.post", side_effect=fake_post):
+        p.generate(prompt="x", lyrics=None, model="music-3.0")
+
+    assert captured["url"] == "https://api.minimaxi.com/v1/music_generation"
+    assert captured["json"]["aigc_watermark"] == os.environ.get("MINIMAX_AIGC_WATERMARK", "0")
+    assert captured["headers"]["Authorization"] == "Bearer test-key"
+
+
+def test_generate_cover_model_sends_audio_url():
+    p = _make_provider()
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["json"] = json
+        return _fake_response(json_data={
+            "base_resp": {"status_code": 0},
+            "data": {"status": 2, "audio": "https://cdn.example.com/cover.mp3"},
+        })
+
+    with patch("backend.app.services.minimax_service.requests.post", side_effect=fake_post):
+        p.generate(prompt=None, lyrics=None, model="music-cover",
+                   audio_url="https://example.com/src.mp3")
+
+    assert captured["json"]["model"] == "music-cover"
+    assert captured["json"]["audio_url"] == "https://example.com/src.mp3"
+
+
+def test_generate_propagates_api_error():
+    p = _make_provider()
+    with patch("backend.app.services.minimax_service.requests.post",
+               return_value=_fake_response(json_data={"base_resp": {"status_code": 1004}, "data": {}})):
+        with pytest.raises(MiniMaxMusicError):
+            p.generate(prompt="x", lyrics=None, model="music-3.0")
+
+
+def test_generate_handles_request_exception():
+    p = _make_provider()
+    with patch("backend.app.services.minimax_service.requests.post",
+               side_effect=_requests.ConnectionError("boom")):
+        with pytest.raises(MiniMaxMusicError):
+            p.generate(prompt="x", lyrics=None, model="music-3.0")
+
+
+def test_get_nested_handles_missing_path():
+    assert MiniMaxMusicProvider._get_nested({"a": {"b": 1}}, "a.b") == 1
+    assert MiniMaxMusicProvider._get_nested({"a": {}}, "a.b") is None
+    assert MiniMaxMusicProvider._get_nested({}, "a.b") is None
+    assert MiniMaxMusicProvider._get_nested({"base_resp": {"status_code": 0}}, "base_resp.status_code") == 0
+
+
+def test_download_audio_returns_bytes():
+    p = _make_provider()
+    fake = MagicMock()
+    fake.content = b"\x00\x01\x02"
+    fake.raise_for_status.return_value = None
+    with patch("backend.app.services.minimax_service.requests.get", return_value=fake):
+        assert p.download_audio("https://cdn.example.com/song.mp3") == b"\x00\x01\x02"


### PR DESCRIPTION
Reason: Open PR #36 adds MiniMax endpoints, model routing, and URL/hex parsing, but its music request schema still omits stream, audio_setting, and lyrics_optimizer and lacks cover input exclusivity, duration, and size validation.

This refresh exposes the current optional request settings, enforces hex output for streaming requests, and validates cover inputs against the documented exclusivity, duration, and size constraints. Preprocessed cover feature IDs remain supported as an alternative to direct reference audio.

Checks:

- `uv run --with pytest --with requests python -m pytest backend/tests/test_minimax_service.py`
- `python3 -m py_compile backend/app/services/minimax_service.py backend/tests/test_minimax_service.py`
- `git diff --check`
- Secret scan on the changed files
